### PR TITLE
Add /toolstats reset-lore Command to Clean Item Lore

### DIFF
--- a/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
@@ -99,6 +99,38 @@ public class CommandToolStats implements TabExecutor {
                 audiences.sender(sender).sendMessage(Component.text("Type /toolstats reset confirm to confirm this.", NamedTextColor.GREEN));
                 return true;
             }
+            case "reset-lore": {
+                if (!sender.hasPermission("toolstats.reset.lore")) {
+                    audiences.sender(sender).sendMessage(Component.text("You do not have permission for this command.", NamedTextColor.RED));
+                    return true;
+                }
+                if (sender instanceof ConsoleCommandSender) {
+                    audiences.sender(sender).sendMessage(Component.text("You must be a player for this command.", NamedTextColor.RED));
+                    return true;
+                }
+
+                Player player = (Player) sender;
+                ItemStack heldItem = player.getInventory().getItemInMainHand();
+
+                if (!toolStats.itemChecker.isValidItem(heldItem.getType())) {
+                    audiences.sender(sender).sendMessage(Component.text("You must hold a valid item.", NamedTextColor.RED));
+                    return true;
+                }
+
+                // Verifica se o item tem lore
+                ItemMeta meta = heldItem.getItemMeta();
+                if (meta == null || !meta.hasLore()) {
+                    audiences.sender(sender).sendMessage(Component.text("This item has no lore to reset.", NamedTextColor.RED));
+                    return true;
+                }
+
+                // Reseta a lore do item
+                meta.setLore(null);
+                heldItem.setItemMeta(meta);
+
+                audiences.sender(sender).sendMessage(Component.text("The item's lore has been reset.", NamedTextColor.GREEN));
+                return true;
+            }
             default: {
                 audiences.sender(sender).sendMessage(Component.text("Invalid sub-command.", NamedTextColor.RED));
             }

--- a/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
@@ -117,14 +117,12 @@ public class CommandToolStats implements TabExecutor {
                     return true;
                 }
 
-                // Verifica se o item tem lore
                 ItemMeta meta = heldItem.getItemMeta();
                 if (meta == null || !meta.hasLore()) {
                     audiences.sender(sender).sendMessage(Component.text("This item has no lore to reset.", NamedTextColor.RED));
                     return true;
                 }
 
-                // Reseta a lore do item
                 meta.setLore(null);
                 heldItem.setItemMeta(meta);
 


### PR DESCRIPTION
#### Summary:
This PR introduces a new command `/toolstats reset-lore`, allowing players to reset the lore of the item they are currently holding in their main hand.

#### Changes:
- Added a new sub-command `reset-lore` to the `onCommand` method in the main command handler.
- The command verifies the following before executing:
  - The sender has the required permission: `toolstats.reset.lore`.
  - The command is executed by a player and not the console.
  - The player is holding a valid item in their main hand.
  - The item has lore that can be reset.
- If all conditions are met, the item's lore is cleared.
- Feedback messages are provided for both successful and unsuccessful command executions.

#### Command Usage:
- `/toolstats reset-lore`
  - Resets the lore of the item held in the player's main hand.
  - Requires the permission: `toolstats.reset.lore`.

#### Additional Info:
- The command will notify the player if:
  - They lack the required permission.
  - They attempt to run the command from the console.
  - They are not holding a valid item or the item has no lore to reset.