### PR TITLE
Command remove lore

### DIFF
--- a/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
@@ -365,10 +365,10 @@ public class CommandToolStats implements TabExecutor {
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
         if (args.length == 1) {
             if (sender.hasPermission("toolstats.reload")) {
-                return Arrays.asList("reset", "reload");
+                return Arrays.asList("reset", "reload", "remove");
             }
             if (sender.hasPermission("toolstats.reset")) {
-                return Collections.singletonList("reset");
+                return Arrays.asList("reset", "remove");
             }
             if (sender.hasPermission("toolstats.remove")) {
                 return Collections.singletonList("remove");
@@ -377,6 +377,11 @@ public class CommandToolStats implements TabExecutor {
         if (args.length == 2) {
             if (args[0].equalsIgnoreCase("reset")) {
                 if (sender.hasPermission("toolstats.reset.confirm")) {
+                    return Collections.singletonList("confirm");
+                }
+            }
+            if (args[0].equalsIgnoreCase("remove")) {
+                if (sender.hasPermission("toolstats.remove.confirm")) {
                     return Collections.singletonList("confirm");
                 }
             }

--- a/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
@@ -370,6 +370,9 @@ public class CommandToolStats implements TabExecutor {
             if (sender.hasPermission("toolstats.reset")) {
                 return Collections.singletonList("reset");
             }
+            if (sender.hasPermission("toolstats.remove")) {
+                return Collections.singletonList("remove");
+            }
         }
         if (args.length == 2) {
             if (args[0].equalsIgnoreCase("reset")) {

--- a/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/commands/CommandToolStats.java
@@ -99,11 +99,56 @@ public class CommandToolStats implements TabExecutor {
                 audiences.sender(sender).sendMessage(Component.text("Type /toolstats reset confirm to confirm this.", NamedTextColor.GREEN));
                 return true;
             }
+            case "remove": {
+                if (!sender.hasPermission("toolstats.remove")) {
+                    audiences.sender(sender).sendMessage(Component.text("You do not have permission for this command.", NamedTextColor.RED));
+                    return true;
+                }
+                if (sender instanceof ConsoleCommandSender) {
+                    audiences.sender(sender).sendMessage(Component.text("You must be a player for this command.", NamedTextColor.RED));
+                    return true;
+                }
+                if (args.length == 2 && args[1].equalsIgnoreCase("confirm")) {
+                    if (!sender.hasPermission("toolstats.remove.confirm")) {
+                        audiences.sender(sender).sendMessage(Component.text("You do not have permission for this command.", NamedTextColor.RED));
+                        return true;
+                    }
+                    Player player = (Player) sender;
+                    ItemStack heldItem = player.getInventory().getItemInMainHand();
+                    if (!toolStats.itemChecker.isValidItem(heldItem.getType())) {
+                        audiences.sender(sender).sendMessage(Component.text("You must hold a valid item.", NamedTextColor.RED));
+                        return true;
+                    }
+                    removeItemLore(heldItem, player);
+                    audiences.sender(sender).sendMessage(Component.text("The lore was reset!", NamedTextColor.GREEN));
+                    return true;
+                }
+                audiences.sender(sender).sendMessage(Component.text("This will remove ALL current lore from the held item.", NamedTextColor.GREEN));
+                audiences.sender(sender).sendMessage(Component.text("ALL custom item lore will be DELETED.", NamedTextColor.GREEN));
+                audiences.sender(sender).sendMessage(Component.text("Type /toolstats remove confirm to confirm this.", NamedTextColor.GREEN));
+                return true;
+            }
             default: {
                 audiences.sender(sender).sendMessage(Component.text("Invalid sub-command.", NamedTextColor.RED));
             }
         }
         return true;
+    }
+
+    /**
+     * Removes lore on a given item.
+     */
+    private void removeItemLore(ItemStack original, Player player) {
+        ItemStack finalItem = original.clone();
+        ItemMeta finalMeta = finalItem.getItemMeta();
+        if (finalMeta == null) {
+            return;
+        }
+
+        finalMeta.setLore(new ArrayList<>());
+        finalItem.setItemMeta(finalMeta);
+        int slot = player.getInventory().getHeldItemSlot();
+        player.getInventory().setItem(slot, finalItem);
     }
 
     /**


### PR DESCRIPTION
This command is similar to reset but does not actually add the lore back. You can run reset after to get the data back, it's still tracked. 

The reason I needed this is because I have a Markets plugin that allows selling tools. These tools stack by default. Of course with the added lore, it's not possible to stack these items anymore.

This was a quick fix .. better potential fixes I am thinking about:
- Allow the markets plugin to stack them, while preserving the data.

Also I am debating better improving the reset methods to PRESERVE custom lore that was added.