### PR TITLE
Fix: catch unhandled exception when version does not exist yet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>lol.hyper</groupId>
     <artifactId>toolstats</artifactId>
-    <version>1.9.2-hotfix-2</version>
+    <version>1.9.3</version>
     <packaging>jar</packaging>
 
     <name>ToolStats</name>

--- a/src/main/java/lol/hyper/toolstats/ToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/ToolStats.java
@@ -19,6 +19,7 @@ package lol.hyper.toolstats;
 
 import lol.hyper.githubreleaseapi.GitHubRelease;
 import lol.hyper.githubreleaseapi.GitHubReleaseAPI;
+import lol.hyper.githubreleaseapi.ReleaseNotFoundException;
 import lol.hyper.toolstats.commands.CommandToolStats;
 import lol.hyper.toolstats.events.*;
 import lol.hyper.toolstats.tools.*;
@@ -251,12 +252,14 @@ public final class ToolStats extends JavaPlugin {
             e.printStackTrace();
             return;
         }
-        GitHubRelease current = api.getReleaseByTag(this.getPluginMeta().getVersion());
-        GitHubRelease latest = api.getLatestVersion();
-        if (current == null) {
+        GitHubRelease current;
+        try{
+            current = api.getReleaseByTag(this.getPluginMeta().getVersion());
+        }catch(ReleaseNotFoundException e){
             logger.warning("You are running a version that does not exist on GitHub. If you are in a dev environment, you can ignore this. Otherwise, this is a bug!");
             return;
         }
+        GitHubRelease latest = api.getLatestVersion();
         int buildsBehind = api.getBuildsBehind(current);
         if (buildsBehind == 0) {
             logger.info("You are running the latest version.");


### PR DESCRIPTION
The exception is thrown when the release does not exist yet. The approach of catching the exception and not evaluating null is cleaner. 
Before:
![unhandledexception](https://github.com/user-attachments/assets/2fcc1e79-0e28-4ec7-b965-674e8d553dc6)
After:
![exceptionfixed](https://github.com/user-attachments/assets/f3d3a702-c79f-4136-b4b0-a44380e49bae)
