### PR TITLE
Add item_model data component support for tokens

### DIFF
--- a/src/main/java/lol/hyper/toolstats/ToolStats.java
+++ b/src/main/java/lol/hyper/toolstats/ToolStats.java
@@ -37,7 +37,7 @@ import java.io.File;
 
 public final class ToolStats extends JavaPlugin {
 
-    public final int CONFIG_VERSION = 17;
+    public final int CONFIG_VERSION = 18;
     public final ComponentLogger logger = this.getComponentLogger();
     public final File configFile = new File(this.getDataFolder(), "config.yml");
     public boolean tokens = false;

--- a/src/main/java/lol/hyper/toolstats/tools/TokenData.java
+++ b/src/main/java/lol/hyper/toolstats/tools/TokenData.java
@@ -238,6 +238,21 @@ public class TokenData {
             }
         }
 
+        // set the item model
+        if (tokenConfig.getBoolean("item-model.enabled")) {
+            String itemModelValue = tokenConfig.getString("item-model.value");
+            if (itemModelValue == null || itemModelValue.isEmpty()) {
+                toolStats.logger.info("Could not find item model value for token {}", tokenType);
+                return null;
+            }
+            NamespacedKey itemModelKey = NamespacedKey.fromString(itemModelValue);
+            if (itemModelKey == null) {
+                toolStats.logger.info("{} is not a valid namespaced key!", itemModelValue);
+                return null;
+            }
+            token.setData(DataComponentTypes.ITEM_MODEL, itemModelKey);
+        }
+
         return token;
     }
 

--- a/src/main/java/lol/hyper/toolstats/tools/config/ConfigUpdater.java
+++ b/src/main/java/lol/hyper/toolstats/tools/config/ConfigUpdater.java
@@ -44,6 +44,7 @@ public class ConfigUpdater {
             case 14 -> new Version15(toolStats).update(); // 14 to 15
             case 15 -> new Version16(toolStats).update(); // 15 to 16
             case 16 -> new Version17(toolStats).update(); // 16 to 17
+            case 17 -> new Version18(toolStats).update(); // 17 to 18
         }
     }
 }

--- a/src/main/java/lol/hyper/toolstats/tools/config/versions/Version18.java
+++ b/src/main/java/lol/hyper/toolstats/tools/config/versions/Version18.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of ToolStats.
+ *
+ * ToolStats is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ToolStats is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ToolStats.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package lol.hyper.toolstats.tools.config.versions;
+
+import lol.hyper.toolstats.ToolStats;
+
+import java.io.File;
+import java.io.IOException;
+
+public class Version18 {
+
+    private final ToolStats toolStats;
+
+    /**
+     * Used for updating from version 17 to 18.
+     *
+     * @param toolStats ToolStats instance.
+     */
+    public Version18(ToolStats toolStats) {
+        this.toolStats = toolStats;
+    }
+
+    /**
+     * Perform the config update.
+     */
+    public void update() {
+        // save the old config first
+        try {
+            toolStats.config.save("plugins" + File.separator + "ToolStats" + File.separator + "config-17.yml");
+        } catch (IOException exception) {
+            toolStats.logger.error("Unable to save config-17.yml!", exception);
+        }
+
+        toolStats.logger.info("Updating config.yml to version 18.");
+        toolStats.config.set("config-version", 18);
+
+        for (String key : toolStats.config.getConfigurationSection("tokens.data").getKeys(false)) {
+            toolStats.logger.info("Adding tokens.data.{}.item-model.enabled", key);
+            toolStats.config.set("tokens.data." + key + ".item-model.enabled", false);
+            toolStats.logger.info("Adding tokens.data.{}.item-model.value", key);
+            toolStats.config.set("tokens.data." + key + ".item-model.value", "minecraft:paper");
+        }
+
+        // save the config and reload it
+        try {
+            toolStats.config.save("plugins" + File.separator + "ToolStats" + File.separator + "config.yml");
+        } catch (IOException exception) {
+            toolStats.logger.error("Unable to save config.yml!", exception);
+        }
+        toolStats.loadConfig();
+        toolStats.logger.info("Config has been updated to version 18. A copy of version 17 has been saved as config-17.yml");
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     mob-kills:
       title: "&7ToolStats: &8Mob Kills Token"
       lore:
@@ -26,6 +29,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     blocks-mined:
       title: "&7ToolStats: &8Blocks Mined Token"
       lore:
@@ -37,6 +43,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     crops-mined:
       title: "&7ToolStats: &8Crops Mined Token"
       lore:
@@ -48,6 +57,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     fish-caught:
       title: "&7ToolStats: &8Fish Caught Token"
       lore:
@@ -59,6 +71,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     sheep-sheared:
       title: "&7ToolStats: &8Sheep Sheared Token"
       lore:
@@ -70,6 +85,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     damage-taken:
       title: "&7ToolStats: &8Damage Taken Token"
       lore:
@@ -81,6 +99,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     damage-done:
       title: "&7ToolStats: &8Damage Done Token"
       lore:
@@ -92,6 +113,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     arrows-shot:
       title: "&7ToolStats: &8Arrows Shot Token"
       lore:
@@ -103,6 +127,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     flight-time:
       title: "&7ToolStats: &8Flight Time Token"
       lore:
@@ -114,6 +141,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     reset:
       title: "&7ToolStats: &8Reset Token"
       lore:
@@ -125,6 +155,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     remove:
       title: "&7ToolStats: &8Remove Token"
       lore:
@@ -136,6 +169,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     wither-kills:
       title: "&7ToolStats: &8Wither Kills Token"
       lore:
@@ -147,6 +183,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     enderdragon-kills:
       title: "&7ToolStats: &8Ender Dragon Kills Token"
       lore:
@@ -158,6 +197,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     critical-strikes:
       title: "&7ToolStats: &8Critical Strikes Token"
       lore:
@@ -169,6 +211,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     trident-throws:
       title: "&7ToolStats: &8Trident Throws Token"
       lore:
@@ -180,6 +225,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
     logs-stripped:
       title: "&7ToolStats: &8Logs Stripped Token"
       lore:
@@ -191,6 +239,9 @@ tokens:
         enabled: false
         type: float
         value: 1001
+      item-model:
+        enabled: false
+        value: "minecraft:paper"
 
 enabled:
   # Will show "Crafted by <player>"
@@ -437,4 +488,4 @@ world-limit:
     - world_1
     - world_2
 
-config-version: 17
+config-version: 18


### PR DESCRIPTION
This PR adds support for the new Minecraft `item_model` data component (introduced in 1.21.4) to the token system, while fully preserving the existing `custom_model_data` functionality.

### Changes
- **`TokenData.java`** — Reads the new `item-model` config block and applies it via `DataComponentTypes.ITEM_MODEL` using a validated `NamespacedKey`.
- **`config.yml`** — Adds `item-model.enabled` and `item-model.value` under every token entry.
- **`ToolStats.java`** — Bumps `CONFIG_VERSION` from `17` to `18`.
- **`ConfigUpdater.java`** — Wires up the `17 → 18` migration path.
- **`Version18.java`** (new) — Config updater that injects `item-model` defaults into existing user configs during automatic migration.

### Backward Compatibility
- Existing `custom-model-data` behavior is **completely untouched**.
- Both `custom-model-data` and `item-model` can be used independently or together.
- Old configs are automatically migrated to version 18 on first load.

### Usage Example
```yaml
tokens:
  data:
    player-kills:
      item-model:
        enabled: true
        value: "nexo:my_custom_token"
```